### PR TITLE
Adds matrix service

### DIFF
--- a/internal/matrix/database/mapper.go
+++ b/internal/matrix/database/mapper.go
@@ -6,28 +6,28 @@ import (
 )
 
 func toDBModel(entity *domain.Matrix) Matrix {
-	matrix := Matrix{
+	m := Matrix{
 		Title:       entity.Title,
 		Description: entity.Description,
-		CourseID:    entity.CourseID,
+		CourseID:    uuid.MustParse(entity.CourseID),
 	}
 
 	if len(entity.UUID) > 0 {
-		matrix.UUID = uuid.MustParse(entity.UUID)
+		m.UUID = uuid.MustParse(entity.UUID)
 	}
 
 	if entity.ID > 0 {
 		// gorm.Model fields
-		matrix.ID = entity.ID
-		matrix.CreatedAt = entity.CreatedAt
-		matrix.UpdatedAt = entity.UpdatedAt
+		m.ID = entity.ID
+		m.CreatedAt = entity.CreatedAt
+		m.UpdatedAt = entity.UpdatedAt
 
 		if !entity.DeletedAt.IsZero() {
-			matrix.DeletedAt = entity.DeletedAt
+			m.DeletedAt = entity.DeletedAt
 		}
 	}
 
-	return matrix
+	return m
 }
 
 func toDomainModel(entity *Matrix) domain.Matrix {
@@ -39,6 +39,6 @@ func toDomainModel(entity *Matrix) domain.Matrix {
 		CreatedAt:   entity.CreatedAt,
 		UpdatedAt:   entity.UpdatedAt,
 		DeletedAt:   entity.DeletedAt,
-		CourseID:    entity.CourseID,
+		CourseID:    entity.CourseID.String(),
 	}
 }

--- a/internal/matrix/database/repository.go
+++ b/internal/matrix/database/repository.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/go-kit/kit/log"
 	"github.com/jinzhu/gorm"
@@ -89,6 +90,26 @@ func (r *Repository) List() ([]domain.Matrix, error) {
 	}
 	if err := query.Error; err != nil {
 		return []domain.Matrix{}, merrors.WrapErrorf(err, merrors.ErrCodeUnknown, "list matrices")
+	}
+
+	var list []domain.Matrix
+	for _, m := range matrices {
+		list = append(list, toDomainModel(&m))
+	}
+
+	return list, nil
+}
+
+func (r *Repository) FindBy(field string, value interface{}) ([]domain.Matrix, error) {
+	var matrices []Matrix
+
+	where := fmt.Sprintf("%s = ?", field)
+	query := r.db.Where(where, value).Find(&matrices)
+	if query.RecordNotFound() {
+		return []domain.Matrix{}, nil
+	}
+	if err := query.Error; err != nil {
+		return []domain.Matrix{}, merrors.WrapErrorf(err, merrors.ErrCodeUnknown, fmt.Sprintf("find matrices by %s", field))
 	}
 
 	var list []domain.Matrix

--- a/internal/matrix/database/schema.go
+++ b/internal/matrix/database/schema.go
@@ -5,15 +5,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
-	"github.com/sumelms/microservice-course/internal/matrix/domain"
 )
 
 type Matrix struct {
 	gorm.Model
-	UUID        uuid.UUID       `gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`
-	Title       string          `gorm:"size:100"`
-	Description string          `gorm:"size:255"`
-	CourseID    domain.CourseID `gorm:"index;"`
+	UUID        uuid.UUID `gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`
+	Title       string    `gorm:"size:100"`
+	Description string    `gorm:"size:255"`
+	CourseID    uuid.UUID `gorm:"type:uuid" sql:"index"`
 }
 
 func (m *Matrix) BeforeCreate(scope *gorm.Scope) error {

--- a/internal/matrix/database/seeder.go
+++ b/internal/matrix/database/seeder.go
@@ -9,8 +9,8 @@ func Matrices() seed.Seed {
 	return seed.Seed{
 		Name: "CreateMatrices",
 		Run: func(db *gorm.DB) error {
-			u := &Matrix{}
-			return db.Create(u).Error
+			m := &Matrix{}
+			return db.Create(m).Error
 		},
 	}
 }

--- a/internal/matrix/domain/matrix.go
+++ b/internal/matrix/domain/matrix.go
@@ -2,15 +2,13 @@ package domain
 
 import "time"
 
-type CourseID uint
-
 type Matrix struct {
 	ID          uint
 	UUID        string
 	Title       string
 	Description string
+	CourseID    string `json:"course_id"`
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 	DeletedAt   *time.Time
-	CourseID    CourseID
 }

--- a/internal/matrix/domain/repository.go
+++ b/internal/matrix/domain/repository.go
@@ -6,4 +6,5 @@ type Repository interface {
 	Update(*Matrix) (Matrix, error)
 	Delete(string) error
 	List() ([]Matrix, error)
+	FindBy(string, interface{}) ([]Matrix, error)
 }

--- a/internal/matrix/domain/service.go
+++ b/internal/matrix/domain/service.go
@@ -13,6 +13,7 @@ type Service interface {
 	FindMatrix(context.Context, string) (Matrix, error)
 	UpdateMatrix(context.Context, *Matrix) (Matrix, error)
 	DeleteMatrix(context.Context, string) error
+	FindMatrixByCourse(context.Context, string) ([]Matrix, error)
 }
 
 type service struct {
@@ -65,4 +66,12 @@ func (s *service) DeleteMatrix(_ context.Context, id string) error {
 		return fmt.Errorf("service can't delete matrix: %w", err)
 	}
 	return nil
+}
+
+func (s *service) FindMatrixByCourse(_ context.Context, courseID string) ([]Matrix, error) {
+	ms, err := s.repo.FindBy("course_id", courseID)
+	if err != nil {
+		return []Matrix{}, fmt.Errorf("service didn't found any matrix to course %s: %v", courseID, err)
+	}
+	return ms, nil
 }

--- a/internal/matrix/endpoints/create_matrix.go
+++ b/internal/matrix/endpoints/create_matrix.go
@@ -16,6 +16,7 @@ import (
 type createMatrixRequest struct {
 	Title       string `json:"title" validate:"required,max=100"`
 	Description string `json:"description" validate:"required,max=255"`
+	CourseID    string `json:"course_id" validate:"required"`
 }
 
 type createMatrixResponse struct {
@@ -24,6 +25,7 @@ type createMatrixResponse struct {
 	Description string    `json:"description"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+	CourseID    string    `json:"course_id"`
 }
 
 func NewCreateMatrixHandler(s domain.Service, opts ...kithttp.ServerOption) *kithttp.Server {
@@ -65,6 +67,7 @@ func makeCreateMatrixEndpoint(s domain.Service) endpoint.Endpoint {
 			Description: created.Description,
 			CreatedAt:   created.CreatedAt,
 			UpdatedAt:   created.UpdatedAt,
+			CourseID:    created.CourseID,
 		}, err
 	}
 }

--- a/internal/matrix/endpoints/find_matrix.go
+++ b/internal/matrix/endpoints/find_matrix.go
@@ -24,6 +24,7 @@ type findMatrixResponse struct {
 	Description string    `json:"description"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+	CourseID    string    `json:"course_id"`
 }
 
 func NewFindMatrixHandler(s domain.Service, opts ...kithttp.ServerOption) *kithttp.Server {
@@ -53,6 +54,7 @@ func makeFindMatrixEndpoint(s domain.Service) endpoint.Endpoint {
 			Description: m.Description,
 			CreatedAt:   m.CreatedAt,
 			UpdatedAt:   m.UpdatedAt,
+			CourseID:    m.CourseID,
 		}, nil
 	}
 }

--- a/internal/matrix/endpoints/find_matrix_by_course.go
+++ b/internal/matrix/endpoints/find_matrix_by_course.go
@@ -1,0 +1,72 @@
+package endpoints
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/sumelms/microservice-course/internal/matrix/domain"
+)
+
+type findMatrixByCourseRequest struct {
+	CourseID string `json:"course_id" validate:"required"`
+}
+
+type findMatrixByCourseResponse struct {
+	Matrices []findMatrixResponse `json:"matrices"`
+}
+
+func NewFindMatrixByCourse(s domain.Service, opts ...kithttp.ServerOption) *kithttp.Server {
+	return kithttp.NewServer(
+		makeFindMatrixByCourseEndpoint(s),
+		decodeFindMatrixByCourseRequest,
+		encodeFindMatrixByCourseResponse,
+		opts...,
+	)
+}
+
+func makeFindMatrixByCourseEndpoint(s domain.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(findMatrixByCourseRequest)
+		if !ok {
+			return nil, fmt.Errorf("invalid argument")
+		}
+
+		matrices, err := s.FindMatrixByCourse(ctx, req.CourseID)
+		if err != nil {
+			return nil, err
+		}
+
+		var list []findMatrixResponse
+		for _, m := range matrices {
+			list = append(list, findMatrixResponse{
+				UUID:        m.UUID,
+				Title:       m.Title,
+				Description: m.Description,
+				CreatedAt:   m.CreatedAt,
+				UpdatedAt:   m.UpdatedAt,
+				CourseID:    m.CourseID,
+			})
+		}
+
+		return &findMatrixByCourseResponse{Matrices: list}, nil
+	}
+}
+
+func decodeFindMatrixByCourseRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	vars := mux.Vars(r)
+	id, ok := vars["uuid"]
+	if !ok {
+		return nil, fmt.Errorf("invalid argument")
+	}
+
+	return findMatrixByCourseRequest{CourseID: id}, nil
+}
+
+func encodeFindMatrixByCourseResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	return kithttp.EncodeJSONResponse(ctx, w, response)
+}

--- a/internal/matrix/endpoints/list_matrix.go
+++ b/internal/matrix/endpoints/list_matrix.go
@@ -37,6 +37,7 @@ func makeListMatrixEndpoint(s domain.Service) endpoint.Endpoint {
 				Description: m.Description,
 				CreatedAt:   m.CreatedAt,
 				UpdatedAt:   m.UpdatedAt,
+				CourseID:    m.CourseID,
 			})
 		}
 

--- a/internal/matrix/endpoints/update_matrix.go
+++ b/internal/matrix/endpoints/update_matrix.go
@@ -20,6 +20,7 @@ type updateMatrixRequest struct {
 	UUID        string `json:"uuid" validate:"required"`
 	Title       string `json:"title" validate:"required,max=100"`
 	Description string `json:"description" validate:"required,max=255"`
+	CourseID    string `json:"course_id" validate:"required"`
 }
 
 type updateMatrixResponse struct {
@@ -28,6 +29,7 @@ type updateMatrixResponse struct {
 	Description string    `json:"description"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+	CourseID    string    `json:"course_id"`
 }
 
 func NewUpdateMatrixHandler(s domain.Service, opts ...kithttp.ServerOption) *kithttp.Server {
@@ -69,6 +71,7 @@ func makeUpdateMatrixEndpoint(s domain.Service) endpoint.Endpoint {
 			Description: updated.Description,
 			CreatedAt:   updated.CreatedAt,
 			UpdatedAt:   updated.UpdatedAt,
+			CourseID:    updated.CourseID,
 		}, nil
 	}
 }

--- a/internal/matrix/transport/http.go
+++ b/internal/matrix/transport/http.go
@@ -24,10 +24,12 @@ func NewHTTPHandler(r *mux.Router, s domain.Service, logger log.Logger) {
 	findMatrixHandler := endpoints.NewFindMatrixHandler(s, opts...)
 	updateMatrixHandler := endpoints.NewUpdateMatrixHandler(s, opts...)
 	deleteMatrixHandler := endpoints.NewDeleteMatrixHandler(s, opts...)
+	findMatrixByCourseHandler := endpoints.NewFindMatrixByCourse(s, opts...)
 
 	r.Handle("/matrices", listMatrixHandler).Methods(http.MethodGet)
 	r.Handle("/matrices", createMatrixHandler).Methods(http.MethodPost)
 	r.Handle("/matrices/{uuid}", findMatrixHandler).Methods(http.MethodGet)
 	r.Handle("/matrices/{uuid}", updateMatrixHandler).Methods(http.MethodPut)
 	r.Handle("/matrices/{uuid}", deleteMatrixHandler).Methods(http.MethodDelete)
+	r.Handle("/matrices/find-by-course-id/{uuid}", findMatrixByCourseHandler).Methods(http.MethodGet)
 }


### PR DESCRIPTION
This PR adds the Course Matrix Service to the Course microservice.

- Basic CRUD functions
- Find by Course ID to being used by the API gateway (`/courses/{courseID}/matrices`)

KrakenD endpoit example:

```json
{
      "endpoint": "/courses/{courseID}/matrices",
      "method": "GET",
      "output_encoding": "json",
      "extra_config": {},
      "backend": [
        {
          "url_pattern": "/courses/{courseID}",
          "encoding": "json",
          "sd": "static",
          "method": "GET",
          "extra_config": {},
          "host": [
            "http://0.0.0.0:8080"
          ],
          "disable_host_sanitize": false
        },
        {
          "url_pattern": "/matrices/find-by-course-id/{courseID}",
          "encoding": "json",
          "sd": "static",
          "method": "GET",
          "extra_config": {
            "github.com/devopsfaith/krakend/proxy": {
              "flatmap_filter": [
                {
                  "type": "append",
                  "args": [
                    "object.*",
                    "object.*"
                  ]
                }
              ]
            }
          },
          "host": [
            "http://0.0.0.0:8080"
          ],
          "disable_host_sanitize": false
        }
      ]
}
```