### PR TITLE
POC: communication between pkgs like services

### DIFF
--- a/internal/course/service.go
+++ b/internal/course/service.go
@@ -12,8 +12,11 @@ import (
 )
 
 func NewHTTPService(router *mux.Router, db *sqlx.DB, logger log.Logger) {
-	repository := &database.Repository{DB: db}
-	service := domain.NewService(repository, logger)
-
+	service := NewService(db, logger)
 	transport.NewHTTPHandler(router, service, logger)
+}
+
+func NewService(db *sqlx.DB, logger log.Logger) *domain.Service {
+	repository := &database.Repository{DB: db}
+	return domain.NewService(repository, logger)
 }

--- a/internal/subscription/service.go
+++ b/internal/subscription/service.go
@@ -7,12 +7,17 @@ import (
 
 	"github.com/sumelms/microservice-course/internal/subscription/database"
 	"github.com/sumelms/microservice-course/internal/subscription/domain"
+	"github.com/sumelms/microservice-course/internal/subscription/service"
 	"github.com/sumelms/microservice-course/internal/subscription/transport"
 )
 
 func NewHTTPService(router *mux.Router, db *sqlx.DB, logger log.Logger) {
-	repository := &database.Repository{DB: db}
-	service := domain.NewService(repository, logger)
-
+	service := NewService(db, logger)
 	transport.NewHTTPHandler(router, service, logger)
+}
+
+func NewService(db *sqlx.DB, logger log.Logger) *domain.Service {
+	repository := &database.Repository{DB: db}
+	courseSvc := service.NewCourseSvc(db, logger)
+	return domain.NewService(repository, courseSvc, logger)
 }

--- a/internal/subscription/service/course_service.go
+++ b/internal/subscription/service/course_service.go
@@ -1,0 +1,28 @@
+package service
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/log"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/sumelms/microservice-course/internal/course"
+	courseDomain "github.com/sumelms/microservice-course/internal/course/domain"
+)
+
+type courseSvc struct {
+	course courseDomain.ServiceInterface
+}
+
+func NewCourseSvc(db *sqlx.DB, logger log.Logger) courseSvc {
+	svc := course.NewService(db, logger)
+	return courseSvc{
+		course: svc,
+	}
+}
+
+func (svc courseSvc) ExistCourse(ctx context.Context, id uuid.UUID) error {
+	_, err := svc.course.Course(ctx, id)
+	return err
+}


### PR DESCRIPTION
A quite simple POC about how to communicate between packages (which can be converted into services after). 

To this POC, I use the create subscription endpoint and I added validation that the course_id received in the request is an existent course.

The idea here is that the `subscription` pkg should know nothing about another pkg (course in that POC) and to get this we use an interface inside the subscription package.

```
type CourseService interface {
	ExistCourse(context.Context, uuid.UUID) error
}
```

This means that the `subscription` services require an svc which provides info about the course, but it doesn't matter if it's db connection or an external service.


And who implements this interface is the `course svc` created in the subscription package `internal/subscription/service/course_service.go` . This service will be responsible to communicate with the course (using the current pkg or another connection)


