### PR TITLE
feat: create prepared statements when the repository is created

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -71,7 +71,9 @@ func main() {
 		course.NewHTTPService(router, db, httpLogger)
 		matrix.NewHTTPService(router, db, httpLogger)
 		subscription.NewHTTPService(router, db, httpLogger)
-		subject.NewHTTPService(router, db, httpLogger)
+		if err := subject.NewHTTPService(router, db, httpLogger); err != nil {
+			panic(err) // TODO treat correctly this error
+		}
 
 		// Handle the router
 		srv.Handle("/", router)

--- a/internal/subject/database/repository.go
+++ b/internal/subject/database/repository.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"fmt"
+
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 
@@ -8,77 +10,107 @@ import (
 	"github.com/sumelms/microservice-course/pkg/errors"
 )
 
-type Repository struct {
-	*sqlx.DB
+const (
+	listSubject    = "list subject"
+	getSubject     = "get subject by uuid"
+	delecteSubject = "delete subject by uuid"
+)
+
+func NewRepository(db *sqlx.DB) (repository, error) {
+	sqlStatements := make(map[string]*sqlx.Stmt)
+
+	for queryName, query := range queries() {
+		stmt, err := db.Preparex(string(query))
+		if err != nil {
+			return repository{}, errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement %s", queryName)
+		}
+		sqlStatements[queryName] = stmt
+	}
+	fmt.Println(sqlStatements)
+	return repository{
+		statements: sqlStatements,
+	}, nil
 }
 
-func (r *Repository) Subject(id uuid.UUID) (domain.Subject, error) {
-	query := `SELECT * FROM subjects WHERE uuid = $1`
+type repository struct {
+	statements map[string]*sqlx.Stmt
+}
 
-	stmt, err := r.Preparex(query)
-	if err != nil {
-		return domain.Subject{}, errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
+type Query string
+
+func queries() map[string]Query {
+	return map[string]Query{
+		listSubject:    Query("SELECT * FROM subjects"),
+		getSubject:     Query("SELECT * FROM subjects WHERE uuid = $1"),
+		delecteSubject: Query("UPDATE subjects SET deleted_at = NOW() WHERE uuid = $1"),
+	}
+}
+
+func (r repository) Subject(id uuid.UUID) (domain.Subject, error) {
+	stmt, ok := r.statements[getSubject]
+	if !ok {
+		return domain.Subject{}, errors.NewErrorf(errors.ErrCodeUnknown, "prepared statement %s not found", getSubject)
 	}
 
 	var sub domain.Subject
-	if err := stmt.Get(&sub, query, id); err != nil {
+	if err := stmt.Get(&sub, id); err != nil {
 		return domain.Subject{}, errors.WrapErrorf(err, errors.ErrCodeUnknown, "error getting subject")
 	}
 	return sub, nil
 }
 
-func (r *Repository) Subjects() ([]domain.Subject, error) {
-	query := `SELECT * FROM subjects`
-
-	stmt, err := r.Preparex(query)
-	if err != nil {
-		return []domain.Subject{}, errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
+func (r repository) Subjects() ([]domain.Subject, error) {
+	stmt, ok := r.statements[listSubject]
+	if !ok {
+		return []domain.Subject{}, errors.NewErrorf(errors.ErrCodeUnknown, "prepared statement %s not found", listSubject)
 	}
 
 	var subs []domain.Subject
-	if err := stmt.Get(&subs, query); err != nil {
+	if err := stmt.Select(&subs); err != nil {
 		return []domain.Subject{}, errors.WrapErrorf(err, errors.ErrCodeUnknown, "error getting subjects")
 	}
 	return subs, nil
 }
 
-func (r *Repository) CreateSubject(sub *domain.Subject) error {
-	query := `INSERT INTO subjects (title) VALUES ($1) RETURNING *`
+func (r repository) CreateSubject(sub *domain.Subject) error {
+	/*
+		query := `INSERT INTO subjects (title) VALUES ($1) RETURNING *`
 
-	stmt, err := r.Preparex(query)
-	if err != nil {
-		return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
-	}
+		stmt, err := r.Preparex(query)
+		if err != nil {
+			return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
+		}
 
-	if err := stmt.Get(sub, query, sub.Title); err != nil {
-		return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error creating course")
-	}
+		if err := stmt.Get(sub, query, sub.Title); err != nil {
+			return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error creating course")
+		}
+	*/
 	return nil
 }
 
-func (r *Repository) UpdateSubject(sub *domain.Subject) error {
-	query := `UPDATE subjects SET title = $1 WHERE uuid = $2 RETURNING *`
+func (r repository) UpdateSubject(sub *domain.Subject) error {
+	/*
+		query := `UPDATE subjects SET title = $1 WHERE uuid = $2 RETURNING *`
 
-	stmt, err := r.Preparex(query)
-	if err != nil {
-		return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
-	}
+		stmt, err := r.Preparex(query)
+		if err != nil {
+			return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
+		}
 
-	if err := stmt.Get(sub, query, sub.Title, sub.UUID); err != nil {
-		return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error updating course")
-	}
+		if err := stmt.Get(sub, query, sub.Title, sub.UUID); err != nil {
+			return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error updating course")
+		}
+	*/
 	return nil
 }
 
-func (r *Repository) DeleteSubject(id uuid.UUID) error {
-	query := `UPDATE subjects SET deleted_at = NOW() WHERE uuid = $1`
-
-	stmt, err := r.Preparex(query)
-	if err != nil {
-		return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error preparing statement")
+func (r repository) DeleteSubject(id uuid.UUID) error {
+	stmt, ok := r.statements[delecteSubject]
+	if !ok {
+		return errors.NewErrorf(errors.ErrCodeUnknown, "prepared statement %s not found", delecteSubject)
 	}
 
-	if _, err := stmt.Exec(query, id); err != nil {
+	if _, err := stmt.Exec(id); err != nil {
 		return errors.WrapErrorf(err, errors.ErrCodeUnknown, "error deleting course")
 	}
 	return nil

--- a/internal/subject/service.go
+++ b/internal/subject/service.go
@@ -10,12 +10,19 @@ import (
 	"github.com/sumelms/microservice-course/internal/subject/transport"
 )
 
-func NewHTTPService(router *mux.Router, db *sqlx.DB, logger log.Logger) {
-	service := NewService(db, logger)
+func NewHTTPService(router *mux.Router, db *sqlx.DB, logger log.Logger) error {
+	service, err := NewService(db, logger)
+	if err != nil {
+		return err
+	}
 	transport.NewHTTPHandler(router, service, logger)
+	return nil
 }
 
-func NewService(db *sqlx.DB, logger log.Logger) *domain.Service {
-	repository := &database.Repository{DB: db}
-	return domain.NewService(repository, logger)
+func NewService(db *sqlx.DB, logger log.Logger) (*domain.Service, error) {
+	repository, err := database.NewRepository(db)
+	if err != nil {
+		return nil, err
+	}
+	return domain.NewService(repository, logger), nil
 }


### PR DESCRIPTION
The idea here is to create the prepared statements when we created the repository. Why?

Because if we just create the prepared statement when we will use it, if the query is wrong we will be noticed just in the execution time, but, if we create the prepared statements when we create the repository ( when the application starts), we can return an error if the prepayment fails, so stop the execution of the application and the deploy (because the application has an error)

It's easy to test it:

We can run the application in the main branch,  changing this query `SELECT * FROM subjects` for `SELECT * FROM subject` (removing the S), the app will start correctly but we will receive an error that the query is wrong when we call the  `statements/` endpoint.

Then, you could do the same in this branch, try to change the query and the app will fail at the beginning.

⚠️ I commented and updated a few things because the application didn't run