### PR TITLE
GitHub Action to release container image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,13 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    name: Liting, Testing and building
+
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,56 @@
+# This is a basic workflow to help you get started with Actions
+name: Publish Container Image
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow when a release is published
+  release:
+    types: [ "published" ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "push_to_registries"
+  push_to_registries:
+    name: Push Docker image to multiple registries
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: 📥 Check out the code
+        uses: actions/checkout@v3
+
+      - name: 🔑 Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: 🔑 Log in to the GH Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔎 Extract metadata (tags, labels) for Container
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}
+
+      - name: 🧰 Build and push Container images
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR:

- Renames `main.yaml` to `ci.yaml`
- Explicit/Adjusts `main.yaml` permissions
- Adds `publish.yaml` that publishes the container image to GHCR and Docker Hub on release event